### PR TITLE
test: покрытие подписочного сервиса и репозитория unit- и dataJpa-тестами

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Apache Commons Compress (fix для CVE, transitive dep из testcontainers) -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/ru/shevchenko/subtracker/repository/SubscriptionRepository.java
+++ b/src/main/java/ru/shevchenko/subtracker/repository/SubscriptionRepository.java
@@ -37,7 +37,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscriptions, Lon
      * @param pageable пагинация (например, top 3)
      * @return список DTO со статистикой подписок
      */
-    @Query("SELECT new SubscriptionStatsDto(s.serviceName, COUNT(s)) " +
+    @Query("SELECT new ru.shevchenko.subtracker.dto.subscription.SubscriptionStatsDto(s.serviceName, COUNT(s)) " +
             "FROM Subscriptions s GROUP BY s.serviceName ORDER BY COUNT(s) DESC")
     List<SubscriptionStatsDto> findTopPopular(Pageable pageable);
 }

--- a/src/test/java/ru/shevchenko/subtracker/repository/SubscriptionRepositoryTest.java
+++ b/src/test/java/ru/shevchenko/subtracker/repository/SubscriptionRepositoryTest.java
@@ -1,0 +1,93 @@
+package ru.shevchenko.subtracker.repository;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import ru.shevchenko.subtracker.dto.subscription.SubscriptionStatsDto;
+import ru.shevchenko.subtracker.model.Subscriptions;
+import ru.shevchenko.subtracker.model.Users;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Testcontainers
+class SubscriptionRepositoryTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16.2-alpine")
+            .withDatabaseName("subtracker_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configure(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        subscriptionRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Проверка existsByUserIdAndServiceName работает корректно")
+    void existsByUserIdAndServiceName_shouldReturnTrue() {
+        Users user = userRepository.save(new Users(null, "Test", "test@mail.ru", null));
+        Subscriptions sub = new Subscriptions(null, "Netflix", user);
+        subscriptionRepository.save(sub);
+
+        boolean exists = subscriptionRepository.existsByUserIdAndServiceName(user.getId(), "Netflix");
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("findByUserId возвращает список подписок")
+    void findByUserId_shouldReturnList() {
+        Users user = userRepository.save(new Users(null, "User", "user@mail.ru", null));
+        subscriptionRepository.save(new Subscriptions(null, "Netflix", user));
+        subscriptionRepository.save(new Subscriptions(null, "YouTube", user));
+
+        List<Subscriptions> result = subscriptionRepository.findByUserId(user.getId());
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("findTopPopular возвращает агрегированные данные")
+    void findTopPopular_shouldReturnStats() {
+        Users u1 = userRepository.save(new Users(null, "A", "a@mail.ru", null));
+        Users u2 = userRepository.save(new Users(null, "B", "b@mail.ru", null));
+
+        subscriptionRepository.save(new Subscriptions(null, "Netflix", u1));
+        subscriptionRepository.save(new Subscriptions(null, "Netflix", u2));
+        subscriptionRepository.save(new Subscriptions(null, "YouTube", u1));
+
+        List<SubscriptionStatsDto> result = subscriptionRepository.findTopPopular(PageRequest.of(0, 3));
+
+        SoftAssertions softly = new SoftAssertions();
+
+        softly.assertThat(result).isNotEmpty();
+        softly.assertThat(result.get(0).getServiceName()).isEqualTo("Netflix");
+        softly.assertThat(result.get(0).getCount()).isEqualTo(2);
+        softly.assertAll();
+    }
+}

--- a/src/test/java/ru/shevchenko/subtracker/service/impl/SubscriptionServiceImplTest.java
+++ b/src/test/java/ru/shevchenko/subtracker/service/impl/SubscriptionServiceImplTest.java
@@ -1,0 +1,158 @@
+package ru.shevchenko.subtracker.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import ru.shevchenko.subtracker.dto.subscription.SubscriptionCreateDto;
+import ru.shevchenko.subtracker.dto.subscription.SubscriptionResponseDto;
+import ru.shevchenko.subtracker.dto.subscription.SubscriptionStatsDto;
+import ru.shevchenko.subtracker.exception.SubscriptionAlreadyExistsException;
+import ru.shevchenko.subtracker.exception.SubscriptionNotFoundException;
+import ru.shevchenko.subtracker.exception.UserNotFoundException;
+import ru.shevchenko.subtracker.mapper.SubscriptionMapper;
+import ru.shevchenko.subtracker.model.Subscriptions;
+import ru.shevchenko.subtracker.model.Users;
+import ru.shevchenko.subtracker.repository.SubscriptionRepository;
+import ru.shevchenko.subtracker.repository.UserRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SubscriptionServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private SubscriptionMapper subscriptionMapper;
+
+    @InjectMocks
+    private SubscriptionServiceImpl subscriptionService;
+
+    @BeforeEach
+    void setUp() {
+        AutoCloseable closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("Добавление подписки — успешный сценарий")
+    void addSubscription_shouldSucceed() {
+        SubscriptionCreateDto dto = new SubscriptionCreateDto("Netflix");
+        Users user = new Users(); user.setId(1L);
+        Subscriptions sub = new Subscriptions(null, "Netflix", user);
+        SubscriptionResponseDto expected = new SubscriptionResponseDto(1L, "Netflix");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(subscriptionRepository.existsByUserIdAndServiceName(1L, "Netflix")).thenReturn(false);
+        when(subscriptionMapper.toEntity(dto)).thenReturn(sub);
+        when(subscriptionRepository.save(sub)).thenReturn(sub);
+        when(subscriptionMapper.toDto(sub)).thenReturn(expected);
+
+        SubscriptionResponseDto result = subscriptionService.addSubscription(1L, dto);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    @DisplayName("Добавление подписки — пользователь не найден")
+    void addSubscription_userNotFound() {
+        SubscriptionCreateDto dto = new SubscriptionCreateDto("Netflix");
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class, () -> subscriptionService.addSubscription(1L, dto));
+    }
+
+    @Test
+    @DisplayName("Добавление подписки — уже существует")
+    void addSubscription_alreadyExists() {
+        SubscriptionCreateDto dto = new SubscriptionCreateDto("Netflix");
+        Users user = new Users(); user.setId(1L);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(subscriptionRepository.existsByUserIdAndServiceName(1L, "Netflix")).thenReturn(true);
+
+        assertThrows(SubscriptionAlreadyExistsException.class, () -> subscriptionService.addSubscription(1L, dto));
+    }
+
+    @Test
+    @DisplayName("Получение подписок по пользователю — успешный сценарий")
+    void getSubscriptionsByUser_shouldReturnList() {
+        Users user = new Users(); user.setId(1L);
+        Subscriptions s = new Subscriptions(1L, "Netflix", user);
+        SubscriptionResponseDto dto = new SubscriptionResponseDto(1L, "Netflix");
+
+        when(userRepository.existsById(1L)).thenReturn(true);
+        when(subscriptionRepository.findByUserId(1L)).thenReturn(List.of(s));
+        when(subscriptionMapper.toDto(s)).thenReturn(dto);
+
+        List<SubscriptionResponseDto> result = subscriptionService.getSubscriptionsByUser(1L);
+
+        assertEquals(1, result.size());
+        assertEquals("Netflix", result.get(0).getServiceName());
+    }
+
+    @Test
+    @DisplayName("Получение подписок — пользователь не найден")
+    void getSubscriptionsByUser_userNotFound() {
+        when(userRepository.existsById(1L)).thenReturn(false);
+        assertThrows(UserNotFoundException.class, () -> subscriptionService.getSubscriptionsByUser(1L));
+    }
+
+    @Test
+    @DisplayName("Удаление подписки — успешный сценарий")
+    void deleteSubscription_shouldDelete() {
+        Users user = new Users(); user.setId(1L);
+        Subscriptions s = new Subscriptions(2L, "VK", user);
+
+        when(subscriptionRepository.findById(2L)).thenReturn(Optional.of(s));
+
+        subscriptionService.deleteSubscription(1L, 2L);
+
+        verify(subscriptionRepository).deleteById(2L);
+    }
+
+    @Test
+    @DisplayName("Удаление подписки — не найдена")
+    void deleteSubscription_notFound() {
+        when(subscriptionRepository.findById(2L)).thenReturn(Optional.empty());
+        assertThrows(SubscriptionNotFoundException.class, () -> subscriptionService.deleteSubscription(1L, 2L));
+    }
+
+    @Test
+    @DisplayName("Удаление подписки — чужая подписка")
+    void deleteSubscription_notBelongToUser() {
+        Users other = new Users(); other.setId(99L);
+        Subscriptions s = new Subscriptions(2L, "VK", other);
+
+        when(subscriptionRepository.findById(2L)).thenReturn(Optional.of(s));
+
+        assertThrows(SubscriptionNotFoundException.class, () -> subscriptionService.deleteSubscription(1L, 2L));
+    }
+
+    @Test
+    @DisplayName("Получение топ-3 подписок")
+    void getTopSubscriptions_shouldReturnList() {
+        List<SubscriptionStatsDto> mockResult = List.of(
+                new SubscriptionStatsDto("Netflix", 5L),
+                new SubscriptionStatsDto("YouTube", 3L)
+        );
+
+        when(subscriptionRepository.findTopPopular(any())).thenReturn(mockResult);
+
+        List<SubscriptionStatsDto> result = subscriptionService.getTopSubscriptions();
+
+        assertEquals(2, result.size());
+        assertEquals("Netflix", result.get(0).getServiceName());
+    }
+}


### PR DESCRIPTION

- Unit-тесты SubscriptionServiceImpl
- DataJpa-тесты SubscriptionRepository с использованием Testcontainers
- Поддержка SoftAssertions и очистка базы перед каждым тестом
- Обновлён pom.xml для подключения PostgreSQL Testcontainers